### PR TITLE
Pagination on Search

### DIFF
--- a/validation/jinja2/validation/_macros.html
+++ b/validation/jinja2/validation/_macros.html
@@ -56,13 +56,13 @@
  #
  # Adapted from: https://docs.djangoproject.com/en/2.1/topics/pagination/
  #}
-{% macro pagination_with_query(page, endpoint, query) %}
+{% macro pagination_with_query(page, endpoint, query, encode_query_with_page) %}
 <ul class="nav justify-content-center">
   {% if page.has_previous() %}
-  <li class="nav-item"><a class="link-nav" href="?page=1{{ query }}">
+  <li class="nav-item"><a class="link-nav" href={{ encode_query_with_page(query, page=1) }}>
       First
   </a></li>
-  <li class="nav-item"><a class="link-nav" href="?page={{ page.previous_page_number() }}{{ query }}">
+  <li class="nav-item"><a class="link-nav" href={{ encode_query_with_page(query, page=page.previous_page_number()) }}>
       Previous
   </a></li>
   {% endif %}
@@ -72,10 +72,10 @@
   </a></li>
 
   {% if page.has_next() %}
-  <li class="nav-item"><a class="link-nav" href="?page={{ page.next_page_number() }}{{ query }}">
+  <li class="nav-item"><a class="link-nav" href={{ encode_query_with_page(query, page=page.next_page_number()) }}>
       Next
   </a></li>
-  <li class="nav-item"><a class="link-nav" href="?page={{ page.paginator.num_pages }}{{ query }}">
+  <li class="nav-item"><a class="link-nav" href={{ encode_query_with_page(query, page=page.paginator.num_pages) }}>
       Last
   </a></li>
   {% endif %}

--- a/validation/jinja2/validation/_macros.html
+++ b/validation/jinja2/validation/_macros.html
@@ -48,6 +48,42 @@
 </ul>
 {% endmacro %}
 
+
+{#
+ # pagination_with_query() -- renders navigation links for a pagination object.
+ #  e.g,. {1} [2] [3] ... [100]
+ # links need query terms in the search pages
+ #
+ # Adapted from: https://docs.djangoproject.com/en/2.1/topics/pagination/
+ #}
+{% macro pagination_with_query(page, endpoint, query) %}
+<ul class="nav justify-content-center">
+  {% if page.has_previous() %}
+  <li class="nav-item"><a class="link-nav" href="?page=1{{ query }}">
+      First
+  </a></li>
+  <li class="nav-item"><a class="link-nav" href="?page={{ page.previous_page_number() }}{{ query }}">
+      Previous
+  </a></li>
+  {% endif %}
+
+  <li class="nav-item"><a class="nav-link active button-nav" href="#">
+      Page {{ page.number }}
+  </a></li>
+
+  {% if page.has_next() %}
+  <li class="nav-item"><a class="link-nav" href="?page={{ page.next_page_number() }}{{ query }}">
+      Next
+  </a></li>
+  <li class="nav-item"><a class="link-nav" href="?page={{ page.paginator.num_pages }}{{ query }}">
+      Last
+  </a></li>
+  {% endif %}
+
+</ul>
+{% endmacro %}
+
+
 {#
  # An audio player for a recording.
  #}

--- a/validation/jinja2/validation/search.html
+++ b/validation/jinja2/validation/search.html
@@ -70,7 +70,7 @@
 </div>
 
 <nav>
-  {{ macros.pagination_with_query(phrases, 'validation:search_phrases', query) }}
+  {{ macros.pagination_with_query(phrases, 'validation:search_phrases', query, encode_query_with_page) }}
 </nav>
 {% endblock content %}
 

--- a/validation/jinja2/validation/search.html
+++ b/validation/jinja2/validation/search.html
@@ -70,7 +70,7 @@
 </div>
 
 <nav>
-  {{ macros.pagination(phrases, 'validation:search_phrases') }}
+  {{ macros.pagination_with_query(phrases, 'validation:search_phrases', query) }}
 </nav>
 {% endblock content %}
 

--- a/validation/views.py
+++ b/validation/views.py
@@ -86,10 +86,13 @@ def search_phrases(request):
     english_matches = Phrase.objects.filter(translation__contains=query)
     all_matches = list(set().union(cree_matches, english_matches))
     all_matches.sort(key=lambda phrase: phrase.transcription)
-    paginator = Paginator(all_matches, 30)
+
+    query_term = f"&query={query}"
+
+    paginator = Paginator(all_matches, 5)
     page_no = request.GET.get("page", 1)
     phrases = paginator.get_page(page_no)
-    context = dict(phrases=phrases, search_term=query)
+    context = dict(phrases=phrases, search_term=query, query=query_term)
     return render(request, "validation/search.html", context)
 
 
@@ -159,10 +162,16 @@ def advanced_search_results(request):
 
     all_matches.sort(key=lambda phrase: phrase.transcription)
 
-    paginator = Paginator(all_matches, 30)
+    query = f"&transcription={transcription}&translation={translation}&analysis={analysis}&status={status}"
+    for speaker in speakers:
+        query += f"&speaker-options={speaker}"
+
+    query += "&speaker="
+
+    paginator = Paginator(all_matches, 5)
     page_no = request.GET.get("page", 1)
     phrases = paginator.get_page(page_no)
-    context = dict(phrases=phrases, search_term="advanced search")
+    context = dict(phrases=phrases, search_term="advanced search", query=query)
     return render(request, "validation/search.html", context)
 
 

--- a/validation/views.py
+++ b/validation/views.py
@@ -371,4 +371,4 @@ def register(request):
 
 def encode_query_with_page(query, page):
     query["page"] = page
-    return f"?{query.urlencode()}" if query else ""
+    return f"?{query.urlencode()}"

--- a/validation/views.py
+++ b/validation/views.py
@@ -366,4 +366,4 @@ def register(request):
 
 def encode_query_with_page(query, page):
     query["page"] = page
-    return query.urlencode()
+    return f"?{query.urlencode()}" if query else ""

--- a/validation/views.py
+++ b/validation/views.py
@@ -88,7 +88,8 @@ def search_phrases(request):
     all_matches = list(set().union(cree_matches, english_matches))
     all_matches.sort(key=lambda phrase: phrase.transcription)
 
-    query_term = QueryDict(f"query={query}", mutable=True)
+    query_term = QueryDict("", mutable=True)
+    query_term.update({"query": query})
 
     paginator = Paginator(all_matches, 5)
     page_no = request.GET.get("page", 1)
@@ -168,13 +169,17 @@ def advanced_search_results(request):
 
     all_matches.sort(key=lambda phrase: phrase.transcription)
 
-    query = f"transcription={transcription}&translation={translation}&analysis={analysis}&status={status}"
+    query = QueryDict("", mutable=True)
+    query.update(
+        {
+            "transcription": transcription,
+            "translation": translation,
+            "analysis": analysis,
+            "status": status,
+        }
+    )
     for speaker in speakers:
-        query += f"&speaker-options={speaker}"
-
-    query += "&speaker="
-
-    query = QueryDict(query, mutable=True)
+        query.appendlist("speaker-options", speaker)
 
     paginator = Paginator(all_matches, 5)
     page_no = request.GET.get("page", 1)


### PR DESCRIPTION
fix #126

Pagination was broken for both basic and advanced search. I now pass the query parameters through the view so the paginator has access to them when loading the next page of results.

I also changed how many results show per page from 30 --> 5, though 5 might be too few results. I'm open to suggestions.