### PR TITLE
Default user group

### DIFF
--- a/validation/views.py
+++ b/validation/views.py
@@ -31,7 +31,7 @@ from django.http import (
     HttpResponseRedirect,
 )
 from django.urls import reverse
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.contrib.auth import authenticate, login as django_login
 
 from librecval.normalization import to_indexable_form
@@ -332,6 +332,8 @@ def register(request):
                     last_name=last_name,
                 )
                 new_user.save()
+                community_group, _ = Group.objects.get_or_create(name="Community")
+                community_group.user_set.add(new_user)
                 response = HttpResponseRedirect("/login")
                 return response
 


### PR DESCRIPTION
New users are added to the Community group when they register. If the group doesn't exist, it will be created. Users who are not community members will need to request access to be added to the Linguist group.