### PR TITLE
Persephone

### DIFF
--- a/validation/management/commands/writetranscriptions.py
+++ b/validation/management/commands/writetranscriptions.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         audio_dir = Path(_path)
 
         query = """
-            select speaker_id, transcription from validation_recording as rec, validation_phrase as p
+            select speaker_id, field_transcription from validation_recording as rec, validation_phrase as p
             where rec.id = ?
             and rec.phrase_id = p.id;
             """

--- a/validation/management/commands/writetranscriptions.py
+++ b/validation/management/commands/writetranscriptions.py
@@ -63,7 +63,9 @@ class Command(BaseCommand):
         self.write_transcriptions(audio_dir, query)
 
     def write_transcriptions(self, audio_dir, query):
-        training_dir = Path("/Users/jolenepoulin/Documents/training/")
+        # Change this to Path("/where/you/want/training/data")
+        # if you want the data elsewhere
+        training_dir = audio_dir
         for audio_file in tqdm(audio_dir.iterdir()):
             audio_id = audio_file.stem
 


### PR DESCRIPTION
## What's in this PR:
This is mainly a refactor of the code that writes transcription files and relocates the audio files so Persephone and Simple4All can use them for training. It uses the `field_transcription` when generating the transcriptions for all the files, but then it uses the `transcription` when generating just the auto-generated transcriptions.

It stills feels a bit messy to me, but it's a little better at least.

I'm unsure if the path "speaker/auto_val/label" will actually work for training, but the files are easy to move once generated.