### PR TITLE
fix: more annoying formats

### DIFF
--- a/librecval/extract_phrases.py
+++ b/librecval/extract_phrases.py
@@ -188,9 +188,7 @@ class RecordingExtractor:
             speaker = self.metadata[session_id][mic_id]
 
             self.logger.debug(
-                "Opening audio and .eaf from %s for speaker %s",
-                sound_file,
-                speaker,
+                "Opening audio and .eaf from %s for speaker %s", sound_file, speaker,
             )
 
             audio = AudioSegment.from_file(fspath(sound_file))
@@ -519,6 +517,8 @@ def get_mic_id(name: str) -> int:
     2
     >>> get_mic_id('2017-06-01pmUS-Track 1_001')
     1
+    >>> get_mic_id('2017-03-09U Spm-Track 1_001')
+    1
     >>> get_mic_id('2016-10-17pm-ds-Track 2_001')
     2
     >>> get_mic_id('2015-04-29-PM-___-_Track_02')
@@ -555,6 +555,9 @@ def get_mic_id(name: str) -> int:
                 \d{2}       # month
                 -
                 \d{2}       # day
+                (?:         # the first possible place for the location 😨
+                    [UD][ ]?S
+                )?
                 (?i:        # case-insensitive AM/PM
                     -?
                     [AP]M
@@ -574,7 +577,7 @@ def get_mic_id(name: str) -> int:
             [tT]rack[_ -]?
         )?
         0*                  # ignore leading zeros
-        (\d+)               # THE MIC NUMBER!
+        (\d)                # THE MIC NUMBER!
         (?:                 # there might be stuff after, but we've already parsed the mic ID so.... ✌️
             _
             .*

--- a/librecval/extract_phrases.py
+++ b/librecval/extract_phrases.py
@@ -58,6 +58,12 @@ class InvalidFileName(RuntimeError):
     """
 
 
+class InvalidAnnotationError(RuntimeError):
+    """
+    Raised when the ELAN file is unusable and should be ignored!
+    """
+
+
 class MissingTranslationError(RuntimeError):
     """
     Raised when the 'English (word)' and 'English (sentence)' tiers
@@ -544,6 +550,26 @@ def get_mic_id(name: str) -> int:
     ...
     extract_phrases.InvalidFileName: Could not determine mic number from: 💩.eaf
     """
+
+    IDIOSYNCRACTIC_FORMATS = {
+        "Track 3 _001 2016-10-03am-ds": 3,
+        "2017-03-USpm-Track 3_001": 3,
+        "2016-05-02pm_ Track 1_003": 1,
+        "2016-04-20am_ Track 2": 2,
+    }
+
+    KNOWN_BAD_ANNOTATION_FILES = {
+        # Looks like annotator tried annotating ALL THREE TRACKS in this file at once,
+        # but then gave up and made separate files for each track (as became standard).
+        # See: /data/av/backup-mwe/2015-05-12pm
+        "2105-05-12pm",
+        # There are newer, better annotations in this directory that superceed this
+        # annotation which is for mic 2, but should be disregarded in preference for the
+        # newer annotations.
+        # See: /data/av/backup-mwe/2015-03-19
+        "2015-03-10-Rain_data",
+    }
+
     # Match something like '2016-02-24am-Track 2_001.eaf'
     m = re.match(
         r"""
@@ -605,5 +631,11 @@ def get_mic_id(name: str) -> int:
         re.VERBOSE,
     )
     if not m:
+        if name in KNOWN_BAD_ANNOTATION_FILES:
+            raise InvalidAnnotationError(
+                f"Tried to get mic for known bad annotation file: {name}"
+            )
+        if name in IDIOSYNCRACTIC_FORMATS:
+            return IDIOSYNCRACTIC_FORMATS[name]
         raise InvalidFileName(f"Could not determine mic number from: {name}")
     return int(m.group(1), 10)

--- a/validation/models.py
+++ b/validation/models.py
@@ -384,9 +384,7 @@ class Recording(models.Model):
     )
 
     comment = models.CharField(
-        help_text="The comment provided in the ELAN file",
-        max_length=256,
-        blank=True,
+        help_text="The comment provided in the ELAN file", max_length=256, blank=True,
     )
 
     # Keep track of the recording's history.


### PR DESCRIPTION
I've  solved ALL of the existing annoying formats. A few of these files should be ignored outright and skipped during the import process.

Here's the output of my script:

```
Could not determine mic number from: Track 3 _001 2016-10-03am-ds
... found in /data/av/backup-mwe/2016-10-03am-ds
Could not determine mic number from: 2017-03-USpm-Track 3_001
... found in /data/av/backup-mwe/2017-03-09USpm
Could not determine mic number from: 2016-05-02pm_ Track 1_003
... found in /data/av/backup-mwe/2016-05-02pm
Could not determine mic number from: 2105-05-12pm
... found in /data/av/backup-mwe/2015-05-12pm
Could not determine mic number from: 2015-03-10-Rain_data
... found in /data/av/backup-mwe/2015-03-19
Could not determine mic number from: 2016-04-20am_ Track 2
... found in /data/av/backup-mwe/2016-04-20am
found 940 elan files; 934 parsed successfully (6 errors)
2 ||||||||||||||||||||||||||| 309
1 |||||||||||||||||||||||||| 302
3 ||||||||||||||||||||||||| 293
4 ||| 24
5 | 4
6 | 2
```