### PR TITLE
Fix/invalid speaker

### DIFF
--- a/librecval/extract_phrases.py
+++ b/librecval/extract_phrases.py
@@ -219,7 +219,7 @@ class RecordingExtractor:
 
             speaker = self.metadata[session_id][mic_id]
 
-            if invalid_speaker(speaker):
+            if speaker is None:
                 raise InvalidSpeakerCode
 
             self.logger.debug(
@@ -520,12 +520,6 @@ def find_audio_from_audition_format(
     )
     logger.debug("[Audition Format] Trying %s...", sound_file)
     return sound_file if sound_file.exists() else None
-
-
-def invalid_speaker(speaker):
-    if not speaker:
-        return True
-    return False
 
 
 WORD_TIER_ENGLISH = 0

--- a/librecval/extract_phrases.py
+++ b/librecval/extract_phrases.py
@@ -63,6 +63,12 @@ class InvalidAnnotationError(RuntimeError):
     """
 
 
+class InvalidSpeakerCode(RuntimeError):
+    """
+    Raised when the speaker code is null
+    """
+
+
 class MissingTranslationError(RuntimeError):
     """
     Raised when the 'English (word)' and 'English (sentence)' tiers
@@ -212,6 +218,9 @@ class RecordingExtractor:
                 self.logger.warning("Assuming single ELAN file is mic 1")
 
             speaker = self.metadata[session_id][mic_id]
+
+            if invalid_speaker(speaker):
+                raise InvalidSpeakerCode
 
             self.logger.debug(
                 "Opening audio and .eaf from %s for speaker %s",
@@ -511,6 +520,12 @@ def find_audio_from_audition_format(
     )
     logger.debug("[Audition Format] Trying %s...", sound_file)
     return sound_file if sound_file.exists() else None
+
+
+def invalid_speaker(speaker):
+    if not speaker:
+        return True
+    return False
 
 
 WORD_TIER_ENGLISH = 0


### PR DESCRIPTION
Raise an error when the speaker code is None. We normalize the speaker code [here](https://github.com/UAlbertaALTLab/recording-validation-interface/blob/dbc91823a265aa4a061cad27bb006f66dcae007f/librecval/recording_session.py#L397) so checking if it's None is pretty safe to do.