### PR TITLE
Make Issue phrase+recording admin fields readonly

### DIFF
--- a/validation/admin.py
+++ b/validation/admin.py
@@ -22,4 +22,8 @@ admin.site.register(Phrase, SimpleHistoryAdmin)
 admin.site.register(RecordingSession)
 admin.site.register(Speaker)  # TODO: use simplehistory
 admin.site.register(Recording, SimpleHistoryAdmin)
-admin.site.register(Issue)
+
+class IssueAdmin(admin.ModelAdmin):
+    readonly_fields = ('phrase', 'recording')
+
+admin.site.register(Issue, IssueAdmin)


### PR DESCRIPTION
Requesting the speaker name and so on for every recording to show a nice
`__str__()` for everything in the select box was sending way too many
requests to the database.

There are some more sophisticated ways to address this here:

https://stackoverflow.com/questions/6892906/how-to-force-django-admin-to-use-select-related