### PR TITLE
fix: temporary static dir on ci

### DIFF
--- a/ci_run_cypress.py
+++ b/ci_run_cypress.py
@@ -6,10 +6,11 @@ It handles the creation of a test database so we know for sure that:
 And then it runs Cypress tests against that test DB
 """
 
-from subprocess import check_call, Popen
 import os
-from pathlib import Path
+import tempfile
 from argparse import ArgumentParser
+from pathlib import Path
+from subprocess import Popen, check_call
 
 parser = ArgumentParser()
 
@@ -17,13 +18,14 @@ parser = ArgumentParser()
 parser.add_argument("--interactive", action="store_true")
 args = parser.parse_args()
 
+
 def modified_env(**kwargs):
     new_env = dict(os.environ)
     new_env.update(kwargs)
     return new_env
 
 
-TEST_SERVER_PORT = '3001'
+TEST_SERVER_PORT = "3001"
 TEST_DB = "test_db.sqlite"
 TEST_DB_FILE = Path(TEST_DB)
 
@@ -33,23 +35,33 @@ TEST_DB_FILE = Path(TEST_DB)
 if TEST_DB_FILE.exists():
     TEST_DB_FILE.unlink()
 
-# Make the test DB!
-m_env = modified_env(RECVAL_SQLITE_DB_PATH=TEST_DB, USE_DJANGO_DEBUG_TOOLBAR="False")
-check_call(["python", "manage.py", "ensuretestdb"], env=m_env)
-check_call(["python", "manage.py", "collectstatic", "--noinput"], env=m_env)
+# Make a place to dump static files:
+with tempfile.TemporaryDirectory(prefix="speech_db_ci_") as temporary_static_directory:
+    m_env = modified_env(
+        RECVAL_SQLITE_DB_PATH=TEST_DB,
+        USE_DJANGO_DEBUG_TOOLBAR="False",
+        STATIC_ROOT=temporary_static_directory,
+    )
+    # Make the test DB!
+    check_call(["python", "manage.py", "ensuretestdb"], env=m_env)
+    check_call(["python", "manage.py", "collectstatic", "--noinput"], env=m_env)
 
-# Start up the server
-server = Popen(["python", "manage.py", "runserver", TEST_SERVER_PORT],
-               env=m_env)
+    # Start up the server
+    server = Popen(["python", "manage.py", "runserver", TEST_SERVER_PORT], env=m_env)
 
-try:
-    cypress_command = "run"
-    if args.interactive:
-        cypress_command = "open"
+    try:
+        cypress_command = "run"
+        if args.interactive:
+            cypress_command = "open"
 
-    # Run Cypress
-    check_call(["node_modules/.bin/cypress", cypress_command],
-    env=modified_env(CYPRESS_BASE_URL=f"http://localhost:{TEST_SERVER_PORT}", USE_DJANGO_DEBUG_TOOLBAR="False"))
-finally:
-    # Stop the server
-    server.terminate()
+        # Run Cypress
+        check_call(
+            ["node_modules/.bin/cypress", cypress_command],
+            env=modified_env(
+                CYPRESS_BASE_URL=f"http://localhost:{TEST_SERVER_PORT}",
+                USE_DJANGO_DEBUG_TOOLBAR="False",
+            ),
+        )
+    finally:
+        # Stop the server
+        server.terminate()


### PR DESCRIPTION
Creates a temporary directory and directs writes there. Honestly, this could probably be fixed by wrangling with Django's confusing collectstatic mechanism elsehow but... that's a PR for another day! 