### PR TITLE
All users can see autovalidated entries

### DIFF
--- a/validation/views.py
+++ b/validation/views.py
@@ -65,10 +65,7 @@ def index(request):
     mode = request.GET.get("mode")
 
     if mode == "all" or not mode:
-        if is_linguist:
-            all_phrases = Phrase.objects.all()
-        else:
-            all_phrases = Phrase.objects.exclude(status="auto-validated")
+        all_phrases = Phrase.objects.all()
     else:
         all_phrases = Phrase.objects.filter(status=mode)
 


### PR DESCRIPTION
## What's in this PR:
* all user types can see autovalidated results, not just the linguists

## Why this PR:
Autovalidated results don't have autovalidated recordings--we still need a human to do this.