### PR TITLE
refactor: clean up recordings search API endpoints

### DIFF
--- a/validation/views.py
+++ b/validation/views.py
@@ -333,16 +333,6 @@ def search_recordings(request, query):
 
     word_forms = frozenset(query.split(","))
 
-    def make_absolute_uri_for_recording(rec: Recording) -> str:
-        uri = rec.compressed_audio.url
-        if uri.startswith("/"):
-            # It's a relative URI: build an absolute URI:
-            return request.build_absolute_uri(uri)
-
-        # It's an absolute URI already:
-        assert uri.startswith("http")
-        return uri
-
     recordings = []
     for form in word_forms:
         # Assume the query is an SRO transcription; prepare it for a fuzzy match.
@@ -364,7 +354,7 @@ def search_recordings(request, query):
                 "anonymous": rec.speaker.anonymous,
                 "gender": rec.speaker.gender,
                 "dialect": rec.speaker.dialect,
-                "recording_url": make_absolute_uri_for_recording(rec),
+                "recording_url": make_absolute_uri_for_recording(request, rec),
                 "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker),
             }
             for rec in result_set

--- a/validation/views.py
+++ b/validation/views.py
@@ -345,17 +345,7 @@ def search_recordings(request, query):
         result_set = exclude_known_bad_recordings(result_set)
 
         recordings.extend(
-            {
-                "wordform": rec.phrase.transcription,
-                "speaker": rec.speaker.code,
-                "speaker_name": rec.speaker.full_name,
-                "anonymous": rec.speaker.anonymous,
-                "gender": rec.speaker.gender,
-                "dialect": rec.speaker.dialect,
-                "recording_url": make_absolute_uri_for_recording(request, rec),
-                "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker),
-            }
-            for rec in result_set
+            create_recording_result_json(request, recording) for recording in result_set
         )
 
     response = JsonResponse(recordings, safe=False)
@@ -388,17 +378,8 @@ def bulk_search_recordings(request):
 
         if result_set:
             matched_recordings.extend(
-                {
-                    "wordform": rec.phrase.transcription,
-                    "speaker": rec.speaker.code,
-                    "speaker_name": rec.speaker.full_name,
-                    "anonymous": rec.speaker.anonymous,
-                    "gender": rec.speaker.gender,
-                    "dialect": rec.speaker.dialect,
-                    "recording_url": make_absolute_uri_for_recording(request, rec),
-                    "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker),
-                }
-                for rec in result_set
+                create_recording_result_json(request, recording)
+                for recording in result_set
             )
         else:
             not_found.append(term)
@@ -670,6 +651,22 @@ def save_issue(data, user):
     )
 
     new_issue.save()
+
+
+def create_recording_result_json(request: HttpRequest, rec: Recording):
+    """
+    Returns JSON that API clients expect for a single recording.
+    """
+    return {
+        "wordform": rec.phrase.transcription,
+        "speaker": rec.speaker.code,
+        "speaker_name": rec.speaker.full_name,
+        "anonymous": rec.speaker.anonymous,
+        "gender": rec.speaker.gender,
+        "dialect": rec.speaker.dialect,
+        "recording_url": make_absolute_uri_for_recording(request, rec),
+        "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker),
+    }
 
 
 def make_absolute_uri_for_speaker_bio(speaker: Speaker) -> str:

--- a/validation/views.py
+++ b/validation/views.py
@@ -342,9 +342,6 @@ def search_recordings(request, query):
         assert uri.startswith("http")
         return uri
 
-    def make_absolute_uri_for_speaker(code: str) -> str:
-        return f"https://www.altlab.dev/maskwacis/Speakers/{code}.html"
-
     recordings = []
     for form in word_forms:
         # Assume the query is an SRO transcription; prepare it for a fuzzy match.
@@ -367,7 +364,7 @@ def search_recordings(request, query):
                 "gender": rec.speaker.gender,
                 "dialect": rec.speaker.dialect,
                 "recording_url": make_absolute_uri_for_recording(rec),
-                "speaker_bio_url": make_absolute_uri_for_speaker(rec.speaker.code),
+                "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker.code),
             }
             for rec in result_set
         )
@@ -397,9 +394,6 @@ def bulk_search_recordings(request):
         assert uri.startswith(("http://", "https://"))
         return uri
 
-    def make_absolute_uri_for_speaker(code: str) -> str:
-        return f"https://www.altlab.dev/maskwacis/Speakers/{code}.html"
-
     query_terms = request.GET.getlist("q")
     matched_recordings = []
     not_found = []
@@ -425,7 +419,9 @@ def bulk_search_recordings(request):
                     "gender": rec.speaker.gender,
                     "dialect": rec.speaker.dialect,
                     "recording_url": make_absolute_uri_for_recording(rec),
-                    "speaker_bio_url": make_absolute_uri_for_speaker(rec.speaker.code),
+                    "speaker_bio_url": make_absolute_uri_for_speaker_bio(
+                        rec.speaker.code
+                    ),
                 }
                 for rec in result_set
             )
@@ -699,3 +695,12 @@ def save_issue(data, user):
     )
 
     new_issue.save()
+
+
+def make_absolute_uri_for_speaker_bio(code: str) -> str:
+    """
+    Returns a URL for where to find the speaker bio.
+    """
+    # TODO: Change this when implementing:
+    # https://github.com/UAlbertaALTLab/recording-validation-interface/issues/72
+    return f"https://www.altlab.dev/maskwacis/Speakers/{code}.html"

--- a/validation/views.py
+++ b/validation/views.py
@@ -364,7 +364,7 @@ def search_recordings(request, query):
                 "gender": rec.speaker.gender,
                 "dialect": rec.speaker.dialect,
                 "recording_url": make_absolute_uri_for_recording(rec),
-                "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker.code),
+                "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker),
             }
             for rec in result_set
         )
@@ -419,9 +419,7 @@ def bulk_search_recordings(request):
                     "gender": rec.speaker.gender,
                     "dialect": rec.speaker.dialect,
                     "recording_url": make_absolute_uri_for_recording(rec),
-                    "speaker_bio_url": make_absolute_uri_for_speaker_bio(
-                        rec.speaker.code
-                    ),
+                    "speaker_bio_url": make_absolute_uri_for_speaker_bio(rec.speaker),
                 }
                 for rec in result_set
             )
@@ -697,10 +695,10 @@ def save_issue(data, user):
     new_issue.save()
 
 
-def make_absolute_uri_for_speaker_bio(code: str) -> str:
+def make_absolute_uri_for_speaker_bio(speaker: Speaker) -> str:
     """
     Returns a URL for where to find the speaker bio.
     """
     # TODO: Change this when implementing:
     # https://github.com/UAlbertaALTLab/recording-validation-interface/issues/72
-    return f"https://www.altlab.dev/maskwacis/Speakers/{code}.html"
+    return f"https://www.altlab.dev/maskwacis/Speakers/{speaker.code}.html"


### PR DESCRIPTION
Just various attempts at try to remove the duplication in the two various recording search API endpoints. A lot of it is gone, but there is some duplication that I think is okay to have (or, more precisely, the solution I'm thinking of to get rid of the duplication is just way too much >.<).

**EDIT**: this is what I mean by "some duplication is okay to have": https://github.com/UAlbertaALTLab/recording-validation-interface/compare/refactor/clean-up-recordings-search...DO-NOT-MERGE/template-method-refactor-i-tried?expand=1