### PR TITLE
change: validate SRO only for words!

### DIFF
--- a/librecval/normalization.py
+++ b/librecval/normalization.py
@@ -78,8 +78,7 @@ def normalize_sro(utterance: str) -> str:
     """
 
     utterance = (
-        nfc(utterance)
-        .strip()
+        normalize_phrase(utterance)
         .lower()
         .replace("e", "ê")
         .translate(MACRON_TO_CIRCUMFLEX)
@@ -90,6 +89,16 @@ def normalize_sro(utterance: str) -> str:
 
     # Ensure there are exactly single spaces between words
     return re.sub(r"\s+", " ", utterance)
+
+
+def normalize_phrase(utterance: str) -> str:
+    """
+    Basic normalization for all phrases in any language:
+
+    >>> normalize_phrase("  Brian n't'siyihka\N{COMBINING MACRON}son  ")
+    "Brian n't'siyihkāson"
+    """
+    return nfc(utterance).strip()
 
 
 def to_indexable_form(text: str) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ plugins =
 [mypy-recvalsite.*,validation.*]
 ignore_errors = True
 
+[mypy-tqdm]
+ignore_missing_imports = True
+
 [mypy.plugins.django-stubs]
 django_settings_module = "recvalsite.settings"
 

--- a/validation/models.py
+++ b/validation/models.py
@@ -188,7 +188,7 @@ class Phrase(models.Model):
 
         if self.kind == self.WORD:
             self.transcription = normalize_sro(self.transcription)
-            if not self.ALLOWED_TRANSCRIPTION_CHARACTERS.issuperset(self.transcription):
+            if not self.transcription_is_in_strict_sro():
                 raise ValidationError(
                     f"Cree word had non-SRO characters: {self.transcription}"
                 )
@@ -197,6 +197,12 @@ class Phrase(models.Model):
         # Make sure the fuzzy match is always up to date
         self.fuzzy_transcription = to_indexable_form(self.transcription)
         super().save(*args, **kwargs)
+
+    def transcription_is_in_strict_sro(self) -> bool:
+        """
+        Returns True when the transcription is written in perfect SRO.
+        """
+        return self.ALLOWED_TRANSCRIPTION_CHARACTERS.issuperset(self.transcription)
 
     def __str__(self) -> str:
         return self.transcription

--- a/validation/tests/test_models.py
+++ b/validation/tests/test_models.py
@@ -239,6 +239,21 @@ def test_phrase_transcription_normalize_ê():
     assert phrase.transcription == "ê-cacâstapiwêt"
 
 
+def test_phrase_transcription_validation():
+    """
+    A ValidationError should be raised ONLY for words that have non-SRO characters.
+    """
+    constants = dict(transcription="Brian", field_transcription="Brian")
+    word = Recipe(Phrase, **constants, kind=Phrase.WORD).prepare()
+    sentence = Recipe(Phrase, **constants, kind=Phrase.SENTENCE).prepare()
+
+    sentence.clean()
+    assert sentence.transcription == constants["transcription"]
+
+    with pytest.raises(ValidationError):
+        word.clean()
+
+
 @pytest.mark.django_db
 def test_phrase_has_history():
     """

--- a/validation/tests/test_models.py
+++ b/validation/tests/test_models.py
@@ -186,6 +186,7 @@ def test_phrase_transcription_normalization(dirty_transcription):
         Phrase,
         transcription=dirty_transcription,
         field_transcription=dirty_transcription,
+        kind=Phrase.WORD,
     ).prepare()
     phrase.clean()
     assert phrase.transcription == nfc(phrase.transcription)
@@ -223,6 +224,7 @@ def test_phrase_transcription_normalization_hyphenation(dirty_transcription, exp
         Phrase,
         transcription=dirty_transcription,
         field_transcription=dirty_transcription,
+        kind=Phrase.WORD,
     ).prepare()
     phrase.clean()
     assert phrase.transcription == expected
@@ -233,7 +235,10 @@ def test_phrase_transcription_normalize_ê():
     Tests that e gets converted to ê.
     """
     phrase = Recipe(
-        Phrase, transcription="e-cacâstapiwet", field_transcription="e-cacâstapiwet"
+        Phrase,
+        transcription="e-cacâstapiwet",
+        field_transcription="e-cacâstapiwet",
+        kind=Phrase.WORD,
     ).prepare()
     phrase.clean()
     assert phrase.transcription == "ê-cacâstapiwêt"


### PR DESCRIPTION
# What is in this PR?

Addresses a concern in #240:

 - **changed**: `Phrase.clean()` now raises a Django `ValidationError`, as it's supposed to
 - **changed**: `Phrase.clean()` only makes a fuss when a _word_ is not in strict SRO. The assumption is that all `Phrase` objects marked as "words" are strictly in Cree.
 - **refactor**: extract `normalize_phrase()` which applies general (non-Cree specific) normalization