### PR TITLE
Add LOGIN_URL to settings

### DIFF
--- a/recvalsite/settings.py
+++ b/recvalsite/settings.py
@@ -218,6 +218,7 @@ MEDIA_URL = config("MEDIA_URL", default="/media/")
 MEDIA_ROOT = config("MEDIA_ROOT", default=BASE_DIR / "data", cast=str)
 
 LOGIN_REDIRECT_URL = "/"
+LOGIN_URL = '/login'
 
 ITWEWINA_URL = "https://itwewina.altlab.app/"
 


### PR DESCRIPTION
Right now, if you’re not logged in, and you click a link to a speech-db page that requires login, you get redirected to https://speech-db.altlab.app/accounts/login/?next=/whatever which is a 404 Not Found page.

This *should* set the correct thing in Django’s internals so that it redirects to the working `/login?next=/whatever` instead.

(I do not have python3.7 on the machine I am currently using, so cannot easily test.)