### PR TITLE
Save Metadata

### DIFF
--- a/validation/forms.py
+++ b/validation/forms.py
@@ -164,3 +164,8 @@ class RecordNewPhrase(forms.ModelForm):
     class Meta:
         model = Recording
         fields = []
+
+    def __init__(self, *args, **kwargs):
+        super(RecordNewPhrase, self).__init__(*args, **kwargs)
+        self.fields["transcription"].label = "Cree"
+        self.fields["translation"].label = "English"

--- a/validation/forms.py
+++ b/validation/forms.py
@@ -150,13 +150,13 @@ class RecordNewPhrase(forms.ModelForm):
     transcription = forms.CharField(
         max_length=256,
         required=False,
-        widget=forms.TextInput(attrs={"class": "form-control form-restrict"}),
+        widget=forms.Textarea(attrs={"class": "form-control issue__textarea"}),
     )
 
     translation = forms.CharField(
         max_length=256,
         required=False,
-        widget=forms.TextInput(attrs={"class": "form-control form-restrict"}),
+        widget=forms.Textarea(attrs={"class": "form-control issue__textarea"}),
     )
 
     file = forms.FileField(widget=forms.HiddenInput())

--- a/validation/views.py
+++ b/validation/views.py
@@ -964,4 +964,4 @@ def save_metadata_to_file(rec_id, user, transcription, translation):
         "dialect": "Plains Cree",
     }
     with open(dest, "w+") as f:
-        json.dump(data, f)
+        json.dump(data, f, indent=2, ensure_ascii=False)

--- a/validation/views.py
+++ b/validation/views.py
@@ -778,10 +778,22 @@ def record_audio(request):
         subprocess.check_call(["ffmpeg", "-i", source, dest], cwd=settings.MEDIA_ROOT)
         rec.compressed_audio = dest
         rec.save()
-        return HttpResponseRedirect("/secrets/record_audio")
+
+        context = dict(
+            form=form,
+            auth=request.user.is_authenticated,
+            is_linguist=user_is_linguist(request.user),
+        )
+        return HttpResponseRedirect("/secrets/record_audio", context)
     else:
         form = RecordNewPhrase()
-    return render(request, "validation/record_audio.html", {"form": form})
+
+    context = dict(
+        form=form,
+        auth=request.user.is_authenticated,
+        is_linguist=user_is_linguist(request.user),
+    )
+    return render(request, "validation/record_audio.html", context)
 
 
 # Small Helper functions

--- a/validation/views.py
+++ b/validation/views.py
@@ -779,6 +779,8 @@ def record_audio(request):
         rec.compressed_audio = dest
         rec.save()
 
+        save_metadata_to_file(rec_id, request.user, transcription, translation)
+
         context = dict(
             form=form,
             auth=request.user.is_authenticated,
@@ -940,3 +942,26 @@ def create_new_rec_id(phrase, speaker):
         f"{time.time()}\n"
     )
     return sha256(signature.encode("UTF-8")).hexdigest()
+
+
+def save_metadata_to_file(rec_id, user, transcription, translation):
+    dest = (
+        settings.MEDIA_ROOT
+        + "/"
+        + settings.RECVAL_AUDIO_PREFIX
+        + "metadata/"
+        + rec_id
+        + ".json"
+    )
+    data = {
+        "audio_file_name": rec_id + ".wav",
+        "user_id": user.id,
+        "username": user.username,
+        "full_name": user.first_name + " " + user.last_name,
+        "recorded_on": str(datetime.datetime.now()),
+        "transcription": transcription,
+        "translation": translation,
+        "dialect": "Plains Cree",
+    }
+    with open(dest, "w+") as f:
+        json.dump(data, f)

--- a/validation/views.py
+++ b/validation/views.py
@@ -958,7 +958,7 @@ def save_metadata_to_file(rec_id, user, transcription, translation):
         "user_id": user.id,
         "username": user.username,
         "full_name": user.first_name + " " + user.last_name,
-        "recorded_on": str(datetime.datetime.now()),
+        "recorded_on": str(datetime.datetime.now().astimezone()),
         "transcription": transcription,
         "translation": translation,
         "dialect": "Plains Cree",


### PR DESCRIPTION
## What's in this PR:
* save the metadata for a user-submitted recording
* give a larger text area
* use "Cree" and "English" instead of "Transcription" and "Translation"
* pass `user.is_authenticated` to the new view so the options menu displays correctly