### PR TITLE
change: only show speakers for current language

### DIFF
--- a/validation/views.py
+++ b/validation/views.py
@@ -140,7 +140,7 @@ def entries(request, language):
 
     recordings, forms = prep_phrase_data(request, phrases, language_object.name)
 
-    speakers = Speaker.objects.all()
+    speakers = Speaker.objects.filter(languages=language_object)
 
     if request.method == "POST":
         form = forms.get(int(request.POST.get("phrase_id")), None)


### PR DESCRIPTION
When filing a wrong speaker using the "Wrong Speaker" button, you could see the speakers from all the languages. Now you can just see the speakers for the current language.