### PR TITLE
fix: fall back to transcription when no field transcription

### DIFF
--- a/validation/views.py
+++ b/validation/views.py
@@ -507,8 +507,8 @@ def segment_content_view(request, language, segment_id):
             p.save()
 
     phrase = Phrase.objects.get(id=segment_id, language=language_object)
-    field_transcription = phrase.field_transcription
-    suggestions = get_distance_with_translations(field_transcription)
+    _transcription = phrase.field_transcription or phrase.transcription
+    suggestions = get_distance_with_translations(_transcription)
 
     segment_name = phrase.transcription
 


### PR DESCRIPTION
The wapamew paradigm wasn't showing spelling suggestions because that function was using the `field_transcription` field, which isn't populated for those entries. I changed it to use the `transcription` field if the `field_transcription` is empty and now it works.