### PR TITLE
fix: issues are paginated

### DIFF
--- a/validation/jinja2/validation/view_issues.html
+++ b/validation/jinja2/validation/view_issues.html
@@ -16,6 +16,7 @@
 #}
 
 {% extends 'validation/_base.html' %}
+{% import 'validation/_macros.html' as macros %}
 
 {% import 'validation/_issue_card.html' as issue_card %}
 
@@ -31,4 +32,7 @@
             </div>
         {% endif %}
     </div>
+    <nav>
+{{ macros.pagination_with_query(issues, 'validation:issues', query, encode_query_with_page) }}
+</nav>
 {% endblock content %}

--- a/validation/views.py
+++ b/validation/views.py
@@ -621,11 +621,17 @@ def view_issues(request, language):
     issues = (
         Issue.objects.filter(status=Issue.OPEN).filter(language=language).order_by("id")
     )
+
+    paginator = Paginator(issues, 10)
+    page_no = request.GET.get("page", 1)
+    paged_issues = paginator.get_page(page_no)
+
     context = dict(
-        issues=issues,
+        issues=paged_issues,
         auth=request.user.is_authenticated,
         is_linguist=user_is_linguist(request.user, language),
         language=language,
+        encode_query_with_page=encode_query_with_page,
     )
     return render(request, "validation/view_issues.html", context)
 
@@ -825,6 +831,7 @@ def save_wrong_speaker_code(request, language, recording_id):
         created_by=request.user,
         created_on=datetime.datetime.now(),
         language=language,
+        status=Issue.OPEN,
     )
     new_issue.save()
 
@@ -861,6 +868,7 @@ def save_wrong_word(request, language, recording_id):
         created_by=request.user,
         created_on=datetime.datetime.now(),
         language=language,
+        status=Issue.OPEN,
     )
     new_issue.save()
 
@@ -1094,6 +1102,8 @@ def handle_save_issue_with_phrase(form, issue, request):
 
 
 def encode_query_with_page(query, page):
+    if not query:
+        query = QueryDict("", mutable=True)
     query["page"] = page
     return f"?{query.urlencode()}"
 
@@ -1154,6 +1164,7 @@ def save_issue(data, user):
         target_language_suggestion=target_language_suggestion,
         created_by=user,
         created_on=datetime.datetime.now(),
+        status=Issue.OPEN,
     )
 
     new_issue.save()


### PR DESCRIPTION
The issues show up 10 at a time on a page now which 1: makes the page faster to load and 2: makes it easier to look at and actually handle some of the issues.