### PR TITLE
Advance search

### DIFF
--- a/validation/views.py
+++ b/validation/views.py
@@ -412,6 +412,10 @@ def advanced_search_results(request, language):
             "analysis": analysis,
             "status": status,
             "kind": kind,
+            "semantic": semantic,
+            "exact": exact,
+            "lemma": lemma,
+            "quality": quality,
         }
     )
     for speaker in speakers:

--- a/validation/views.py
+++ b/validation/views.py
@@ -316,11 +316,17 @@ def advanced_search_results(request, language):
     is_linguist = user_is_linguist(request.user, language)
     is_expert = user_is_expert(request.user, language)
 
-    transcription = request.GET.get("transcription").strip()
-    translation = request.GET.get("translation").strip()
+    transcription = request.GET.get("transcription")
+    if transcription:
+        transcription = transcription.strip()
+    translation = request.GET.get("translation")
+    if translation:
+        translation = translation.strip()
     exact = request.GET.get("exact")
     analysis = request.GET.get("analysis")
-    lemma = request.GET.get("lemma").strip()
+    lemma = request.GET.get("lemma")
+    if lemma:
+        lemma = lemma.strip()
     kind = request.GET.get("kind")
     status = request.GET.get("status")
     semantic = request.GET.get("semantic_class")


### PR DESCRIPTION
Fix: #412 
Added all query terms to query for encoding when pressing navigation buttons.

Note: I can't test this locally, but this should be the fix.