### PR TITLE
fix: swap transcription and translation

### DIFF
--- a/librecval/extract_auto.py
+++ b/librecval/extract_auto.py
@@ -73,8 +73,8 @@ class SynthesizedRecordingExtractor:
             audio = AudioSegment.from_file(fspath(audio_file))
 
             s = Segment(
-                translation=entry,
-                transcription="",
+                translation="",
+                transcription=entry,
                 fixed_transcription="",
                 quality=Recording.UNKNOWN,
                 session=session_id,


### PR DESCRIPTION
The transcription and translation were in the wrong fields. That has been fixed.